### PR TITLE
TASK-014: convoy detail view with tracked issues

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		GT080006 /* RigsManifest.swift in Sources */ = {isa = PBXBuildFile; fileRef = GT080016 /* RigsManifest.swift */; };
 		GT080007 /* RoleDirectory.swift in Sources */ = {isa = PBXBuildFile; fileRef = GT080017 /* RoleDirectory.swift */; };
 		GT080008 /* RigInventoryAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = GT080018 /* RigInventoryAdapter.swift */; };
+		GT013001 /* ConvoyAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = GT013011 /* ConvoyAdapter.swift */; };
 			A5001001 /* cmuxApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001011 /* cmuxApp.swift */; };
 			A5001002 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001012 /* ContentView.swift */; };
 			E62155868BB29FEB5DAAAF25 /* SidebarSelectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AD52285508B1D6A9875E7B3 /* SidebarSelectionState.swift */; };
@@ -222,6 +223,7 @@
 		GT080016 /* RigsManifest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RigsManifest.swift; sourceTree = "<group>"; };
 		GT080017 /* RoleDirectory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoleDirectory.swift; sourceTree = "<group>"; };
 		GT080018 /* RigInventoryAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RigInventoryAdapter.swift; sourceTree = "<group>"; };
+		GT013011 /* ConvoyAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConvoyAdapter.swift; sourceTree = "<group>"; };
 			A5001000 /* Gmux.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Gmux.app; sourceTree = BUILT_PRODUCTS_DIR; };
 			F1000002A1B2C3D4E5F60718 /* cmuxTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = cmuxTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 			7E7E6EF344A568AC7FEE3715 /* cmuxUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = cmuxUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -639,6 +641,7 @@
 		GT080020 /* GasTown */ = {
 			isa = PBXGroup;
 			children = (
+				GT013011 /* ConvoyAdapter.swift */,
 				GT080011 /* GasTownRoot.swift */,
 				GT080012 /* Rig.swift */,
 				GT080013 /* RigConfig.swift */,
@@ -888,6 +891,7 @@
 			GT080006 /* RigsManifest.swift in Sources */,
 			GT080007 /* RoleDirectory.swift in Sources */,
 			GT080008 /* RigInventoryAdapter.swift in Sources */,
+			GT013001 /* ConvoyAdapter.swift in Sources */,
 		);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -34,6 +34,8 @@
 		A5001226 /* SocketControlSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001225 /* SocketControlSettings.swift */; };
 		A5001601 /* SentryHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001600 /* SentryHelper.swift */; };
 		A5001621 /* AppleScriptSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001620 /* AppleScriptSupport.swift */; };
+		A5001660 /* GasTownDiscovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001661 /* GasTownDiscovery.swift */; };
+		A5001670 /* BeadsAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001671 /* BeadsAdapter.swift */; };
 		D1320AA0D1320AA0D1320AA1 /* AppIconDockTilePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1320AA0D1320AA0D1320AA4 /* AppIconDockTilePlugin.swift */; };
 		D1320AA0D1320AA0D1320AA2 /* CmuxDockTilePlugin.plugin in Copy Dock Tile Plugin */ = {isa = PBXBuildFile; fileRef = D1320AA0D1320AA0D1320AA5 /* CmuxDockTilePlugin.plugin */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		A5001400 /* Panel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001410 /* Panel.swift */; };
@@ -241,6 +243,8 @@
 		A5001019 /* TerminalController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalController.swift; sourceTree = "<group>"; };
 		A5001600 /* SentryHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryHelper.swift; sourceTree = "<group>"; };
 		A5001620 /* AppleScriptSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleScriptSupport.swift; sourceTree = "<group>"; };
+		A5001661 /* GasTownDiscovery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GasTownDiscovery.swift; sourceTree = "<group>"; };
+		A5001671 /* BeadsAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeadsAdapter.swift; sourceTree = "<group>"; };
 		D1320AA0D1320AA0D1320AA4 /* AppIconDockTilePlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconDockTilePlugin.swift; sourceTree = "<group>"; };
 		A5001510 /* CmuxWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/CmuxWebView.swift; sourceTree = "<group>"; };
 			A5001511 /* UITestRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITestRecorder.swift; sourceTree = "<group>"; };
@@ -495,6 +499,8 @@
 				A5001225 /* SocketControlSettings.swift */,
 				A5001600 /* SentryHelper.swift */,
 				A5001620 /* AppleScriptSupport.swift */,
+				A5001661 /* GasTownDiscovery.swift */,
+				A5001671 /* BeadsAdapter.swift */,
 				D1320AA0D1320AA0D1320AA4 /* AppIconDockTilePlugin.swift */,
 				A5001090 /* AppDelegate.swift */,
 				A5001091 /* NotificationsPage.swift */,
@@ -835,6 +841,8 @@
 				A5001226 /* SocketControlSettings.swift in Sources */,
 				A5001601 /* SentryHelper.swift in Sources */,
 				A5001621 /* AppleScriptSupport.swift in Sources */,
+				A5001660 /* GasTownDiscovery.swift in Sources */,
+				A5001670 /* BeadsAdapter.swift in Sources */,
 				A5001093 /* AppDelegate.swift in Sources */,
 				A5001094 /* NotificationsPage.swift in Sources */,
 				A5001095 /* TerminalNotificationStore.swift in Sources */,

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -48,6 +48,8 @@
 		A5007420 /* BrowserPopupWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5007421 /* BrowserPopupWindowController.swift */; };
 		A5001420 /* MarkdownPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001418 /* MarkdownPanel.swift */; };
 		A5001421 /* MarkdownPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001419 /* MarkdownPanelView.swift */; };
+		GT014001 /* ConvoyDetailPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = GT014011 /* ConvoyDetailPanel.swift */; };
+		GT014002 /* ConvoyDetailPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = GT014012 /* ConvoyDetailPanelView.swift */; };
 		A5001290 /* MarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = A5001291 /* MarkdownUI */; };
 		A5001405 /* PanelContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001415 /* PanelContentView.swift */; };
 		A5001406 /* Workspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001416 /* Workspace.swift */; };
@@ -262,6 +264,8 @@
 		A5001415 /* PanelContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/PanelContentView.swift; sourceTree = "<group>"; };
 		A5001418 /* MarkdownPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownPanel.swift; sourceTree = "<group>"; };
 		A5001419 /* MarkdownPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownPanelView.swift; sourceTree = "<group>"; };
+		GT014011 /* ConvoyDetailPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/ConvoyDetailPanel.swift; sourceTree = "<group>"; };
+		GT014012 /* ConvoyDetailPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/ConvoyDetailPanelView.swift; sourceTree = "<group>"; };
 		A5001416 /* Workspace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Workspace.swift; sourceTree = "<group>"; };
 		A5001417 /* WorkspaceContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceContentView.swift; sourceTree = "<group>"; };
 		A5001090 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -519,6 +523,8 @@
 				A5007421 /* BrowserPopupWindowController.swift */,
 				A5001418 /* MarkdownPanel.swift */,
 				A5001419 /* MarkdownPanelView.swift */,
+				GT014011 /* ConvoyDetailPanel.swift */,
+				GT014012 /* ConvoyDetailPanelView.swift */,
 				A5001510 /* CmuxWebView.swift */,
 				A5001415 /* PanelContentView.swift */,
 				A5001211 /* UpdateController.swift */,
@@ -861,6 +867,8 @@
 				A5007420 /* BrowserPopupWindowController.swift in Sources */,
 				A5001420 /* MarkdownPanel.swift in Sources */,
 				A5001421 /* MarkdownPanelView.swift in Sources */,
+				GT014001 /* ConvoyDetailPanel.swift in Sources */,
+				GT014002 /* ConvoyDetailPanelView.swift in Sources */,
 				A5001500 /* CmuxWebView.swift in Sources */,
 				A5001405 /* PanelContentView.swift in Sources */,
 				A5001201 /* UpdateController.swift in Sources */,

--- a/Sources/BeadsAdapter.swift
+++ b/Sources/BeadsAdapter.swift
@@ -1,0 +1,402 @@
+import Foundation
+
+// MARK: - Beads Adapter
+//
+// Read-only adapter over the Beads CLI (`bd`) and routes file.
+// Normalizes Beads output into app models that downstream views
+// (convoy, ready-work, bead-detail) can consume without embedding
+// shell invocations or JSON parsing in UI code.
+//
+// Consumed by: TASK-015 (ready-work surface), TASK-016 (bead-detail),
+// and convoy-linked issue context.
+//
+// Design: stateless, value-oriented, injectable environment (same
+// pattern as GasTownDiscovery). All models are Equatable + Sendable.
+
+// MARK: - Domain Models
+
+/// A routing rule mapping a bead ID prefix to a rig path.
+struct BeadRoute: Equatable, Sendable, Identifiable {
+    /// The bead ID prefix (e.g. "gm-", "hq-", "sc-").
+    let prefix: String
+    /// Relative path from the Town root to the rig directory (e.g. "gmux", ".").
+    let path: String
+
+    var id: String { prefix }
+}
+
+/// Summary of a bead as returned by `bd ready` or `bd list`.
+struct BeadSummary: Equatable, Sendable, Identifiable {
+    let id: String
+    let title: String
+    let status: String
+    let priority: Int
+    let issueType: String
+    let assignee: String?
+    let owner: String?
+    let createdAt: String?
+    let labels: [String]
+    let dependencyCount: Int
+    let dependentCount: Int
+}
+
+/// A dependency edge between two beads.
+struct BeadDependency: Equatable, Sendable {
+    let id: String
+    let title: String
+    let status: String
+    let dependencyType: String
+}
+
+/// Full detail of a single bead as returned by `bd show <id> --json`.
+struct BeadDetail: Equatable, Sendable, Identifiable {
+    let id: String
+    let title: String
+    let description: String?
+    let acceptanceCriteria: String?
+    let status: String
+    let priority: Int
+    let issueType: String
+    let assignee: String?
+    let owner: String?
+    let estimatedMinutes: Int?
+    let createdAt: String?
+    let createdBy: String?
+    let updatedAt: String?
+    let externalRef: String?
+    let dependencies: [BeadDependency]
+}
+
+// MARK: - Error Types
+
+/// Structured error describing why a Beads adapter operation failed.
+enum BeadsAdapterError: Error, Equatable, Sendable {
+    /// The `bd` CLI binary could not be found on PATH.
+    case bdCLINotFound
+    /// The `bd` CLI exited with a non-zero status.
+    case cliFailure(command: String, exitCode: Int32, stderr: String)
+    /// The CLI produced output that could not be parsed as JSON.
+    case parseFailure(command: String, detail: String)
+    /// The routes file could not be read or parsed.
+    case routesFileUnreadable(path: String, detail: String)
+    /// The requested bead was not found.
+    case beadNotFound(id: String)
+}
+
+// MARK: - Adapter Result Wrapper
+
+/// Wraps an adapter result with explicit status so views can distinguish
+/// between "no data yet", "data loaded", and "failed with reason".
+enum BeadsLoadState<T: Equatable & Sendable>: Equatable, Sendable {
+    case idle
+    case loading
+    case loaded(T)
+    case failed(BeadsAdapterError)
+}
+
+// MARK: - Adapter
+
+/// Read-only adapter for Beads data: routes, ready work, and bead detail.
+///
+/// Designed as a stateless value-oriented service. Downstream views hold
+/// their own `BeadsLoadState` and call adapter methods to populate it.
+struct BeadsAdapter {
+
+    // MARK: - Configuration
+
+    /// Abstraction over environment, filesystem, and CLI access for testability.
+    struct Environment: Sendable {
+        var contentsOfFile: @Sendable (String) -> Data?
+        var fileExists: @Sendable (String) -> Bool
+        var whichBD: @Sendable () -> String?
+        var runCLI: @Sendable (_ executablePath: String, _ arguments: [String]) -> CLIResult
+
+        static let live = Environment(
+            contentsOfFile: { path in
+                FileManager.default.contents(atPath: path)
+            },
+            fileExists: { path in
+                FileManager.default.fileExists(atPath: path)
+            },
+            whichBD: {
+                BeadsAdapter.resolveBDCLI()
+            },
+            runCLI: { executablePath, arguments in
+                BeadsAdapter.runProcess(executablePath: executablePath, arguments: arguments)
+            }
+        )
+    }
+
+    /// Result of running a CLI command.
+    struct CLIResult: Equatable, Sendable {
+        let exitCode: Int32
+        let stdout: Data
+        let stderr: Data
+    }
+
+    let environment: Environment
+
+    init(environment: Environment = .live) {
+        self.environment = environment
+    }
+
+    // MARK: - Public API
+
+    /// Load bead routing rules from the Town's `routes.jsonl` file.
+    ///
+    /// Each line in routes.jsonl is a JSON object with `prefix` and `path` keys.
+    /// This reads the file directly without invoking the CLI.
+    func loadRoutes(townRootPath: String) -> Result<[BeadRoute], BeadsAdapterError> {
+        let routesPath = (townRootPath as NSString).appendingPathComponent(".beads/routes.jsonl")
+
+        guard environment.fileExists(routesPath) else {
+            return .failure(.routesFileUnreadable(
+                path: routesPath,
+                detail: String(
+                    localized: "beads.routes.notFound",
+                    defaultValue: "Routes file does not exist at '\(routesPath)'."
+                )
+            ))
+        }
+
+        guard let data = environment.contentsOfFile(routesPath) else {
+            return .failure(.routesFileUnreadable(
+                path: routesPath,
+                detail: String(
+                    localized: "beads.routes.unreadable",
+                    defaultValue: "Could not read routes file at '\(routesPath)'."
+                )
+            ))
+        }
+
+        guard let content = String(data: data, encoding: .utf8) else {
+            return .failure(.routesFileUnreadable(
+                path: routesPath,
+                detail: String(
+                    localized: "beads.routes.encoding",
+                    defaultValue: "Routes file is not valid UTF-8."
+                )
+            ))
+        }
+
+        var routes: [BeadRoute] = []
+        for line in content.split(separator: "\n") {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.isEmpty { continue }
+
+            guard let lineData = trimmed.data(using: .utf8),
+                  let json = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any],
+                  let prefix = json["prefix"] as? String,
+                  let path = json["path"] as? String else {
+                continue
+            }
+
+            routes.append(BeadRoute(prefix: prefix, path: path))
+        }
+
+        return .success(routes)
+    }
+
+    /// Load beads that are ready to work (no unresolved blockers).
+    ///
+    /// Invokes `bd ready --json` and parses the result into `BeadSummary` models.
+    func loadReadyWork() -> Result<[BeadSummary], BeadsAdapterError> {
+        guard let bdPath = environment.whichBD() else {
+            return .failure(.bdCLINotFound)
+        }
+
+        let result = environment.runCLI(bdPath, ["ready", "--json"])
+
+        if result.exitCode != 0 {
+            let stderr = String(data: result.stderr, encoding: .utf8) ?? ""
+            return .failure(.cliFailure(
+                command: "bd ready --json",
+                exitCode: result.exitCode,
+                stderr: stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+            ))
+        }
+
+        guard let array = try? JSONSerialization.jsonObject(with: result.stdout) as? [[String: Any]] else {
+            let raw = String(data: result.stdout, encoding: .utf8) ?? "<binary>"
+            return .failure(.parseFailure(
+                command: "bd ready --json",
+                detail: String(
+                    localized: "beads.ready.parseFailed",
+                    defaultValue: "Expected JSON array from 'bd ready --json'. Got: \(raw.prefix(200))"
+                )
+            ))
+        }
+
+        let summaries = array.compactMap { parseBeadSummary($0) }
+        return .success(summaries)
+    }
+
+    /// Load full detail for a single bead by ID.
+    ///
+    /// Invokes `bd show <id> --json` and parses the result into a `BeadDetail`.
+    func loadBeadDetail(id: String) -> Result<BeadDetail, BeadsAdapterError> {
+        guard let bdPath = environment.whichBD() else {
+            return .failure(.bdCLINotFound)
+        }
+
+        let result = environment.runCLI(bdPath, ["show", id, "--json"])
+
+        if result.exitCode != 0 {
+            let stderr = String(data: result.stderr, encoding: .utf8) ?? ""
+            if stderr.contains("not found") || stderr.contains("no such") {
+                return .failure(.beadNotFound(id: id))
+            }
+            return .failure(.cliFailure(
+                command: "bd show \(id) --json",
+                exitCode: result.exitCode,
+                stderr: stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+            ))
+        }
+
+        // `bd show` returns a JSON array with a single element.
+        guard let array = try? JSONSerialization.jsonObject(with: result.stdout) as? [[String: Any]],
+              let first = array.first else {
+            let raw = String(data: result.stdout, encoding: .utf8) ?? "<binary>"
+            return .failure(.parseFailure(
+                command: "bd show \(id) --json",
+                detail: String(
+                    localized: "beads.detail.parseFailed",
+                    defaultValue: "Expected JSON array from 'bd show'. Got: \(raw.prefix(200))"
+                )
+            ))
+        }
+
+        guard let detail = parseBeadDetail(first) else {
+            return .failure(.parseFailure(
+                command: "bd show \(id) --json",
+                detail: String(
+                    localized: "beads.detail.modelFailed",
+                    defaultValue: "Could not map JSON to BeadDetail for bead '\(id)'."
+                )
+            ))
+        }
+
+        return .success(detail)
+    }
+
+    // MARK: - JSON Parsing
+
+    private func parseBeadSummary(_ json: [String: Any]) -> BeadSummary? {
+        guard let id = json["id"] as? String,
+              let title = json["title"] as? String else {
+            return nil
+        }
+
+        return BeadSummary(
+            id: id,
+            title: title,
+            status: json["status"] as? String ?? "unknown",
+            priority: json["priority"] as? Int ?? 0,
+            issueType: json["issue_type"] as? String ?? "unknown",
+            assignee: json["assignee"] as? String,
+            owner: json["owner"] as? String,
+            createdAt: json["created_at"] as? String,
+            labels: json["labels"] as? [String] ?? [],
+            dependencyCount: json["dependency_count"] as? Int ?? 0,
+            dependentCount: json["dependent_count"] as? Int ?? 0
+        )
+    }
+
+    private func parseBeadDetail(_ json: [String: Any]) -> BeadDetail? {
+        guard let id = json["id"] as? String,
+              let title = json["title"] as? String else {
+            return nil
+        }
+
+        var dependencies: [BeadDependency] = []
+        if let deps = json["dependencies"] as? [[String: Any]] {
+            for dep in deps {
+                guard let depId = dep["id"] as? String,
+                      let depTitle = dep["title"] as? String else {
+                    continue
+                }
+                dependencies.append(BeadDependency(
+                    id: depId,
+                    title: depTitle,
+                    status: dep["status"] as? String ?? "unknown",
+                    dependencyType: dep["dependency_type"] as? String ?? "blocks"
+                ))
+            }
+        }
+
+        return BeadDetail(
+            id: id,
+            title: title,
+            description: json["description"] as? String,
+            acceptanceCriteria: json["acceptance_criteria"] as? String,
+            status: json["status"] as? String ?? "unknown",
+            priority: json["priority"] as? Int ?? 0,
+            issueType: json["issue_type"] as? String ?? "unknown",
+            assignee: json["assignee"] as? String,
+            owner: json["owner"] as? String,
+            estimatedMinutes: json["estimated_minutes"] as? Int,
+            createdAt: json["created_at"] as? String,
+            createdBy: json["created_by"] as? String,
+            updatedAt: json["updated_at"] as? String,
+            externalRef: json["external_ref"] as? String,
+            dependencies: dependencies
+        )
+    }
+
+    // MARK: - CLI Helpers
+
+    /// Attempt to find the `bd` binary on PATH.
+    static func resolveBDCLI() -> String? {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/which")
+        task.arguments = ["bd"]
+        let pipe = Pipe()
+        task.standardOutput = pipe
+        task.standardError = FileHandle.nullDevice
+        do {
+            try task.run()
+            task.waitUntilExit()
+            if task.terminationStatus == 0 {
+                let data = pipe.fileHandleForReading.readDataToEndOfFile()
+                let path = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
+                if let path, !path.isEmpty {
+                    return path
+                }
+            }
+        } catch {
+            // which not available or failed — bd not on PATH.
+        }
+        return nil
+    }
+
+    /// Run a CLI process and capture stdout + stderr.
+    static func runProcess(executablePath: String, arguments: [String]) -> CLIResult {
+        let process = Process()
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        process.executableURL = URL(fileURLWithPath: executablePath)
+        process.arguments = arguments
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+
+        do {
+            try process.run()
+        } catch {
+            return CLIResult(
+                exitCode: -1,
+                stdout: Data(),
+                stderr: Data("Failed to launch process: \(error.localizedDescription)".utf8)
+            )
+        }
+
+        let stdout = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
+        let stderr = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+
+        return CLIResult(
+            exitCode: process.terminationStatus,
+            stdout: stdout,
+            stderr: stderr
+        )
+    }
+}

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -6025,6 +6025,8 @@ struct ContentView: View {
             return String(localized: "commandPalette.kind.browser", defaultValue: "Browser")
         case .markdown:
             return String(localized: "commandPalette.kind.markdown", defaultValue: "Markdown")
+        case .convoy:
+            return String(localized: "commandPalette.kind.convoy", defaultValue: "Convoy")
         }
     }
 
@@ -6036,6 +6038,8 @@ struct ContentView: View {
             return ["browser", "web", "page"]
         case .markdown:
             return ["markdown", "note", "preview"]
+        case .convoy:
+            return ["convoy", "work", "issues", "tracking"]
         }
     }
 

--- a/Sources/GasTown/ConvoyAdapter.swift
+++ b/Sources/GasTown/ConvoyAdapter.swift
@@ -1,0 +1,532 @@
+import Foundation
+
+// MARK: - Convoy Adapter
+//
+// Read-only adapter over the Gas Town CLI (`gt`) for convoy data.
+// Maps `gt convoy list --json` and `gt convoy show <id> --json` into
+// domain models that downstream views (cockpit dashboard, detail panel,
+// notification routing) can consume without embedding shell invocations
+// or JSON parsing in UI code.
+//
+// Convoy semantics (from deep-research-report.md):
+//   - Convoys are persistent, town-level beads (`hq-cv-*`) that track
+//     batched work across rigs.
+//   - Swarms are ephemeral groupings within a convoy.
+//   - A "stranded convoy" has ready work but no polecats assigned — this
+//     is an attention-worthy state the operator should act on.
+//
+// Consumed by: TASK-014 (convoy detail UI), TASK-018 (attention routing),
+// and the operator cockpit dashboard.
+//
+// Design: stateless, value-oriented, injectable environment (same pattern
+// as BeadsAdapter and GasTownDiscovery). All models are Equatable + Sendable.
+
+// MARK: - Attention State
+
+/// The attention state of a convoy — signals whether operator action is needed.
+///
+/// Attention states are derived from convoy data, not stored upstream.
+/// The derivation logic lives in `ConvoyAdapter` so all consumers share
+/// the same rules.
+enum ConvoyAttentionState: String, Equatable, Sendable, CaseIterable {
+    /// Normal progress — no operator action required.
+    case normal
+    /// Stranded — ready (unblocked, open) issues exist but no polecats are assigned.
+    case stranded
+    /// Blocked — all remaining issues have unresolved blockers.
+    case blocked
+}
+
+// MARK: - Domain Models
+
+/// Dashboard-ready summary of a convoy from `gt convoy list --json`.
+///
+/// Contains enough data for the attention dashboard to display status dots,
+/// progress, and stranded-work signals without a detail fetch.
+struct ConvoySummary: Equatable, Sendable, Identifiable {
+    /// Convoy bead ID (e.g. `hq-cv-abc`).
+    let id: String
+    /// Human-readable title.
+    let title: String
+    /// Upstream status string (typically `"open"` or `"closed"`).
+    let status: String
+    /// Total tracked issues in this convoy.
+    let totalIssues: Int
+    /// Tracked issues with `"closed"` status.
+    let completedIssues: Int
+    /// Derived attention state for operator triage.
+    let attention: ConvoyAttentionState
+    /// Number of polecats currently assigned to tracked issues.
+    let assignedPolecats: Int
+    /// Rig IDs that have tracked issues in this convoy.
+    let rigIds: [String]
+    /// When the convoy was created (ISO 8601 string from upstream).
+    let createdAt: String?
+    /// When the convoy was last updated (ISO 8601 string from upstream).
+    let updatedAt: String?
+
+    /// Progress as a fraction in [0.0, 1.0].
+    var progress: Double {
+        guard totalIssues > 0 else { return 0.0 }
+        return Double(completedIssues) / Double(totalIssues)
+    }
+
+    /// Whether this convoy needs operator attention.
+    var needsAttention: Bool {
+        attention != .normal
+    }
+}
+
+/// A tracked issue within a convoy, from `gt convoy show <id> --json`.
+struct ConvoyTrackedIssue: Equatable, Sendable, Identifiable {
+    let id: String
+    let title: String
+    let status: String
+    let assignee: String?
+    /// The rig this issue belongs to (derived from bead prefix routing).
+    let rigId: String?
+    let priority: Int
+}
+
+/// Full detail for a selected convoy from `gt convoy show <id> --json`.
+///
+/// Provides the tracked-issue list and progress context needed by the
+/// convoy detail view (TASK-014).
+struct ConvoyDetail: Equatable, Sendable, Identifiable {
+    let id: String
+    let title: String
+    let status: String
+    let description: String?
+    let trackedIssues: [ConvoyTrackedIssue]
+    let attention: ConvoyAttentionState
+    /// Rig IDs that have tracked issues in this convoy.
+    let rigIds: [String]
+    let createdAt: String?
+    let updatedAt: String?
+
+    var totalIssues: Int { trackedIssues.count }
+    var completedIssues: Int { trackedIssues.filter { $0.status == "closed" }.count }
+
+    var progress: Double {
+        guard totalIssues > 0 else { return 0.0 }
+        return Double(completedIssues) / Double(totalIssues)
+    }
+}
+
+// MARK: - Error Types
+
+/// Structured error describing why a convoy adapter operation failed.
+enum ConvoyAdapterError: Error, Equatable, Sendable {
+    /// The `gt` CLI binary could not be found on PATH.
+    case gtCLINotFound
+    /// The `gt` CLI exited with a non-zero status.
+    case cliFailure(command: String, exitCode: Int32, stderr: String)
+    /// The CLI produced output that could not be parsed as JSON.
+    case parseFailure(command: String, detail: String)
+    /// The requested convoy was not found.
+    case convoyNotFound(id: String)
+}
+
+// MARK: - Load State
+
+/// Wraps a convoy adapter result with explicit status so views can
+/// distinguish between "no data yet", "data loaded", and "failed with reason".
+enum ConvoyLoadState<T: Equatable & Sendable>: Equatable, Sendable {
+    case idle
+    case loading
+    case loaded(T)
+    case failed(ConvoyAdapterError)
+}
+
+// MARK: - Refresh Strategy
+
+/// Configures how frequently and under what conditions convoy data
+/// should be refreshed. Downstream coordinators (view models, stores)
+/// use this to schedule reloads without hardcoding timing.
+struct ConvoyRefreshStrategy: Equatable, Sendable {
+    /// Minimum interval between automatic refreshes.
+    let autoRefreshInterval: TimeInterval
+    /// Whether to refresh when the app returns to foreground.
+    let refreshOnForeground: Bool
+
+    /// Suitable for an operator monitoring active work — refreshes every
+    /// 30 seconds and on foreground return.
+    static let operatorDefault = ConvoyRefreshStrategy(
+        autoRefreshInterval: 30,
+        refreshOnForeground: true
+    )
+
+    /// Manual-only refresh — no automatic reloads.
+    static let manual = ConvoyRefreshStrategy(
+        autoRefreshInterval: .infinity,
+        refreshOnForeground: false
+    )
+}
+
+// MARK: - Adapter
+
+/// Read-only adapter for convoy data from the Gas Town CLI.
+///
+/// Stateless and value-oriented. Downstream views hold their own
+/// `ConvoyLoadState` and call adapter methods to populate it.
+/// The adapter derives attention states from raw convoy data so
+/// all consumers share consistent stranded/blocked detection.
+struct ConvoyAdapter {
+
+    // MARK: - Configuration
+
+    /// Abstraction over environment and CLI access for testability.
+    struct Environment: Sendable {
+        var whichGT: @Sendable () -> String?
+        var runCLI: @Sendable (_ executablePath: String, _ arguments: [String]) -> CLIResult
+
+        static let live = Environment(
+            whichGT: {
+                GasTownDiscovery.resolveGTCLI()
+            },
+            runCLI: { executablePath, arguments in
+                ConvoyAdapter.runProcess(executablePath: executablePath, arguments: arguments)
+            }
+        )
+    }
+
+    /// Result of running a CLI command.
+    struct CLIResult: Equatable, Sendable {
+        let exitCode: Int32
+        let stdout: Data
+        let stderr: Data
+    }
+
+    let environment: Environment
+
+    init(environment: Environment = .live) {
+        self.environment = environment
+    }
+
+    // MARK: - Public API
+
+    /// Load active convoy summaries suitable for the operator dashboard.
+    ///
+    /// Invokes `gt convoy list --json` and maps each entry into a
+    /// `ConvoySummary` with a derived attention state.
+    func loadActiveConvoys() -> Result<[ConvoySummary], ConvoyAdapterError> {
+        guard let gtPath = environment.whichGT() else {
+            return .failure(.gtCLINotFound)
+        }
+
+        let result = environment.runCLI(gtPath, ["convoy", "list", "--json"])
+
+        if result.exitCode != 0 {
+            let stderr = String(data: result.stderr, encoding: .utf8) ?? ""
+            return .failure(.cliFailure(
+                command: "gt convoy list --json",
+                exitCode: result.exitCode,
+                stderr: stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+            ))
+        }
+
+        guard let array = try? JSONSerialization.jsonObject(with: result.stdout) as? [[String: Any]] else {
+            let raw = String(data: result.stdout, encoding: .utf8) ?? "<binary>"
+            return .failure(.parseFailure(
+                command: "gt convoy list --json",
+                detail: String(
+                    localized: "convoy.list.parseFailed",
+                    defaultValue: "Expected JSON array from 'gt convoy list --json'. Got: \(raw.prefix(200))"
+                )
+            ))
+        }
+
+        let summaries = array.compactMap { parseConvoySummary($0) }
+        return .success(summaries)
+    }
+
+    /// Load all convoys (including closed) for historical views.
+    ///
+    /// Invokes `gt convoy list --all --json`.
+    func loadAllConvoys() -> Result<[ConvoySummary], ConvoyAdapterError> {
+        guard let gtPath = environment.whichGT() else {
+            return .failure(.gtCLINotFound)
+        }
+
+        let result = environment.runCLI(gtPath, ["convoy", "list", "--all", "--json"])
+
+        if result.exitCode != 0 {
+            let stderr = String(data: result.stderr, encoding: .utf8) ?? ""
+            return .failure(.cliFailure(
+                command: "gt convoy list --all --json",
+                exitCode: result.exitCode,
+                stderr: stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+            ))
+        }
+
+        guard let array = try? JSONSerialization.jsonObject(with: result.stdout) as? [[String: Any]] else {
+            let raw = String(data: result.stdout, encoding: .utf8) ?? "<binary>"
+            return .failure(.parseFailure(
+                command: "gt convoy list --all --json",
+                detail: String(
+                    localized: "convoy.listAll.parseFailed",
+                    defaultValue: "Expected JSON array from 'gt convoy list --all --json'. Got: \(raw.prefix(200))"
+                )
+            ))
+        }
+
+        let summaries = array.compactMap { parseConvoySummary($0) }
+        return .success(summaries)
+    }
+
+    /// Load full detail for a single convoy by ID.
+    ///
+    /// Invokes `gt convoy show <id> --json` and parses the result into
+    /// a `ConvoyDetail` with tracked issues and derived attention state.
+    func loadConvoyDetail(id: String) -> Result<ConvoyDetail, ConvoyAdapterError> {
+        guard let gtPath = environment.whichGT() else {
+            return .failure(.gtCLINotFound)
+        }
+
+        let result = environment.runCLI(gtPath, ["convoy", "show", id, "--json"])
+
+        if result.exitCode != 0 {
+            let stderr = String(data: result.stderr, encoding: .utf8) ?? ""
+            if stderr.contains("not found") || stderr.contains("no such") {
+                return .failure(.convoyNotFound(id: id))
+            }
+            return .failure(.cliFailure(
+                command: "gt convoy show \(id) --json",
+                exitCode: result.exitCode,
+                stderr: stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+            ))
+        }
+
+        guard let json = try? JSONSerialization.jsonObject(with: result.stdout) as? [String: Any] else {
+            // Some commands return a single-element array.
+            if let array = try? JSONSerialization.jsonObject(with: result.stdout) as? [[String: Any]],
+               let first = array.first {
+                return parseConvoyDetailResult(first, id: id)
+            }
+
+            let raw = String(data: result.stdout, encoding: .utf8) ?? "<binary>"
+            return .failure(.parseFailure(
+                command: "gt convoy show \(id) --json",
+                detail: String(
+                    localized: "convoy.detail.parseFailed",
+                    defaultValue: "Expected JSON from 'gt convoy show'. Got: \(raw.prefix(200))"
+                )
+            ))
+        }
+
+        return parseConvoyDetailResult(json, id: id)
+    }
+
+    // MARK: - JSON Parsing
+
+    private func parseConvoySummary(_ json: [String: Any]) -> ConvoySummary? {
+        guard let id = json["id"] as? String,
+              let title = json["title"] as? String else {
+            return nil
+        }
+
+        let trackedIssues = json["tracked_issues"] as? [[String: Any]] ?? []
+        let totalIssues = (json["total_issues"] as? Int) ?? trackedIssues.count
+        let completedIssues = (json["completed_issues"] as? Int)
+            ?? trackedIssues.filter { ($0["status"] as? String) == "closed" }.count
+
+        let assignedPolecats = deriveAssignedPolecatCount(from: trackedIssues)
+        let rigIds = deriveRigIds(from: trackedIssues)
+        let attention = deriveAttentionState(
+            status: json["status"] as? String ?? "open",
+            trackedIssues: trackedIssues,
+            totalIssues: totalIssues,
+            completedIssues: completedIssues
+        )
+
+        return ConvoySummary(
+            id: id,
+            title: title,
+            status: json["status"] as? String ?? "open",
+            totalIssues: totalIssues,
+            completedIssues: completedIssues,
+            attention: attention,
+            assignedPolecats: assignedPolecats,
+            rigIds: rigIds,
+            createdAt: json["created_at"] as? String,
+            updatedAt: json["updated_at"] as? String
+        )
+    }
+
+    private func parseConvoyDetailResult(
+        _ json: [String: Any],
+        id requestedId: String
+    ) -> Result<ConvoyDetail, ConvoyAdapterError> {
+        guard let id = json["id"] as? String,
+              let title = json["title"] as? String else {
+            return .failure(.parseFailure(
+                command: "gt convoy show \(requestedId) --json",
+                detail: String(
+                    localized: "convoy.detail.modelFailed",
+                    defaultValue: "Could not map JSON to ConvoyDetail for convoy '\(requestedId)'."
+                )
+            ))
+        }
+
+        let rawIssues = json["tracked_issues"] as? [[String: Any]] ?? []
+        let trackedIssues = rawIssues.compactMap { parseTrackedIssue($0) }
+        let rigIds = deriveRigIds(from: rawIssues)
+        let attention = deriveAttentionState(
+            status: json["status"] as? String ?? "open",
+            trackedIssues: rawIssues,
+            totalIssues: trackedIssues.count,
+            completedIssues: trackedIssues.filter { $0.status == "closed" }.count
+        )
+
+        let detail = ConvoyDetail(
+            id: id,
+            title: title,
+            status: json["status"] as? String ?? "open",
+            description: json["description"] as? String,
+            trackedIssues: trackedIssues,
+            attention: attention,
+            rigIds: rigIds,
+            createdAt: json["created_at"] as? String,
+            updatedAt: json["updated_at"] as? String
+        )
+        return .success(detail)
+    }
+
+    private func parseTrackedIssue(_ json: [String: Any]) -> ConvoyTrackedIssue? {
+        guard let id = json["id"] as? String,
+              let title = json["title"] as? String else {
+            return nil
+        }
+
+        return ConvoyTrackedIssue(
+            id: id,
+            title: title,
+            status: json["status"] as? String ?? "unknown",
+            assignee: json["assignee"] as? String,
+            rigId: json["rig_id"] as? String ?? deriveRigId(fromBeadId: id),
+            priority: json["priority"] as? Int ?? 0
+        )
+    }
+
+    // MARK: - Attention State Derivation
+
+    /// Derive the attention state for a convoy from its tracked issues.
+    ///
+    /// Rules (evaluated in priority order):
+    /// 1. Closed convoys are always `.normal`.
+    /// 2. If open issues exist that are not blocked and not assigned → `.stranded`.
+    /// 3. If all remaining (non-closed) issues are blocked → `.blocked`.
+    /// 4. Otherwise → `.normal` (work is progressing).
+    private func deriveAttentionState(
+        status: String,
+        trackedIssues: [[String: Any]],
+        totalIssues: Int,
+        completedIssues: Int
+    ) -> ConvoyAttentionState {
+        // Closed convoys need no attention.
+        if status == "closed" { return .normal }
+
+        // All done — nothing to flag.
+        if totalIssues > 0 && completedIssues >= totalIssues { return .normal }
+
+        let openIssues = trackedIssues.filter { ($0["status"] as? String) != "closed" }
+        if openIssues.isEmpty { return .normal }
+
+        let blockedStatuses: Set<String> = ["blocked"]
+        let blocked = openIssues.filter { blockedStatuses.contains($0["status"] as? String ?? "") }
+        let unblocked = openIssues.filter { !blockedStatuses.contains($0["status"] as? String ?? "") }
+
+        // All remaining issues are blocked — nothing can progress.
+        if !openIssues.isEmpty && blocked.count == openIssues.count {
+            return .blocked
+        }
+
+        // Stranded: unblocked issues exist but none have an assignee with a polecat role.
+        let hasAssignedWork = unblocked.contains { issue in
+            guard let assignee = issue["assignee"] as? String, !assignee.isEmpty else {
+                return false
+            }
+            // Polecat assignees follow the pattern "<rig>/polecats/<name>".
+            return assignee.contains("/polecats/")
+        }
+
+        if !unblocked.isEmpty && !hasAssignedWork {
+            return .stranded
+        }
+
+        return .normal
+    }
+
+    /// Count distinct polecats assigned to tracked issues.
+    private func deriveAssignedPolecatCount(from issues: [[String: Any]]) -> Int {
+        var polecats: Set<String> = []
+        for issue in issues {
+            if let assignee = issue["assignee"] as? String,
+               assignee.contains("/polecats/") {
+                polecats.insert(assignee)
+            }
+        }
+        return polecats.count
+    }
+
+    /// Extract unique rig IDs from tracked issues.
+    private func deriveRigIds(from issues: [[String: Any]]) -> [String] {
+        var rigs: Set<String> = []
+        for issue in issues {
+            if let rigId = issue["rig_id"] as? String {
+                rigs.insert(rigId)
+            } else if let id = issue["id"] as? String, let derived = deriveRigId(fromBeadId: id) {
+                rigs.insert(derived)
+            }
+        }
+        return rigs.sorted()
+    }
+
+    /// Derive a rig ID from a bead ID prefix.
+    ///
+    /// Bead IDs like `gm-abc` map to rig `gmux` via routes.jsonl. This is
+    /// a best-effort heuristic for display; the authoritative mapping is
+    /// in the Beads routes file. Returns `nil` if no prefix can be extracted.
+    private func deriveRigId(fromBeadId id: String) -> String? {
+        // Extract the prefix portion (everything up to and including the first hyphen).
+        guard let hyphenIndex = id.firstIndex(of: "-") else { return nil }
+        let prefix = String(id[...hyphenIndex])
+        // The prefix alone is not a rig name, but it is useful for grouping.
+        // Return it as-is; downstream consumers with access to routes can resolve
+        // the full rig name.
+        return prefix.isEmpty ? nil : prefix
+    }
+
+    // MARK: - CLI Helpers
+
+    /// Run a CLI process and capture stdout + stderr.
+    static func runProcess(executablePath: String, arguments: [String]) -> CLIResult {
+        let process = Process()
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        process.executableURL = URL(fileURLWithPath: executablePath)
+        process.arguments = arguments
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+
+        do {
+            try process.run()
+        } catch {
+            return CLIResult(
+                exitCode: -1,
+                stdout: Data(),
+                stderr: Data("Failed to launch process: \(error.localizedDescription)".utf8)
+            )
+        }
+
+        let stdout = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
+        let stderr = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+
+        return CLIResult(
+            exitCode: process.terminationStatus,
+            stdout: stdout,
+            stderr: stderr
+        )
+    }
+}

--- a/Sources/GasTownDiscovery.swift
+++ b/Sources/GasTownDiscovery.swift
@@ -1,0 +1,397 @@
+import Foundation
+
+// MARK: - Town Root Detection & Prerequisite Validation
+//
+// Detection search order:
+//   1. GT_TOWN_ROOT environment variable (authoritative when set by gt CLI)
+//   2. GT_ROOT environment variable (legacy alias)
+//   3. Walk up from the current working directory looking for .beads/routes.jsonl
+//   4. Check ~/code/spectralGasTown (common developer layout) — not hardcoded;
+//      the walk-up strategy covers any layout.
+//
+// Town root marker: a directory containing .beads/routes.jsonl
+// Rig marker: a subdirectory containing config.json with "type": "rig"
+
+// MARK: - Data Types
+
+/// Identifies a validated Gas Town root on disk.
+struct TownRoot: Equatable, Sendable {
+    /// Absolute path to the Town root directory.
+    let path: String
+
+    /// Absolute path to the `.beads/routes.jsonl` file.
+    var routesPath: String { (path as NSString).appendingPathComponent(".beads/routes.jsonl") }
+
+    /// Absolute path to the `.beads` directory.
+    var beadsPath: String { (path as NSString).appendingPathComponent(".beads") }
+}
+
+/// Minimal rig metadata read from `<rig>/config.json`.
+struct RigInfo: Equatable, Sendable, Identifiable {
+    let name: String
+    /// Absolute path to the rig directory (e.g. `<town>/gmux`).
+    let path: String
+    let gitURL: String?
+    let defaultBranch: String?
+    let beadsPrefix: String?
+
+    var id: String { name }
+}
+
+/// A prerequisite that Town detection can validate.
+enum TownPrerequisite: String, CaseIterable, Sendable {
+    case townRootExists = "town-root-exists"
+    case beadsDirectoryExists = "beads-directory-exists"
+    case routesFileExists = "routes-file-exists"
+    case atLeastOneRig = "at-least-one-rig"
+    case gtCLIAvailable = "gt-cli-available"
+}
+
+/// Result of checking a single prerequisite.
+struct PrerequisiteResult: Equatable, Sendable {
+    let prerequisite: TownPrerequisite
+    let passed: Bool
+    /// Human-readable guidance when the prerequisite fails.
+    let guidance: String?
+}
+
+/// Structured error describing why Town detection failed.
+enum TownDetectionError: Error, Equatable, Sendable {
+    /// No Town root could be located through any detection strategy.
+    case noTownRoot(searchedPaths: [String])
+    /// A candidate Town root was found but is missing required structure.
+    case invalidTownLayout(path: String, failures: [PrerequisiteResult])
+    /// The `gt` CLI is not installed or not on PATH.
+    case gtCLINotFound
+}
+
+/// Successful detection result with the validated Town and its rigs.
+struct TownDiscoveryResult: Equatable, Sendable {
+    let town: TownRoot
+    let rigs: [RigInfo]
+    let prerequisites: [PrerequisiteResult]
+    let gtCLIPath: String?
+}
+
+// MARK: - Discovery Service
+
+/// Locates a Gas Town root, validates prerequisites, and enumerates rigs.
+///
+/// Designed as a stateless value-oriented service so later inventory and identity
+/// tasks can reuse it without coupling to any particular view or lifecycle.
+struct GasTownDiscovery {
+
+    // MARK: - Configuration
+
+    /// Abstraction over environment and filesystem access for testability.
+    struct Environment: Sendable {
+        var getenv: @Sendable (String) -> String?
+        var fileExists: @Sendable (String) -> Bool
+        var isDirectory: @Sendable (String) -> Bool
+        var contentsOfDirectory: @Sendable (String) -> [String]
+        var contentsOfFile: @Sendable (String) -> Data?
+        var currentDirectoryPath: @Sendable () -> String
+        var homeDirectoryPath: @Sendable () -> String
+        var whichGT: @Sendable () -> String?
+
+        static let live = Environment(
+            getenv: { key in
+                ProcessInfo.processInfo.environment[key]
+            },
+            fileExists: { path in
+                FileManager.default.fileExists(atPath: path)
+            },
+            isDirectory: { path in
+                var isDir: ObjCBool = false
+                return FileManager.default.fileExists(atPath: path, isDirectory: &isDir) && isDir.boolValue
+            },
+            contentsOfDirectory: { path in
+                (try? FileManager.default.contentsOfDirectory(atPath: path)) ?? []
+            },
+            contentsOfFile: { path in
+                FileManager.default.contents(atPath: path)
+            },
+            currentDirectoryPath: {
+                FileManager.default.currentDirectoryPath
+            },
+            homeDirectoryPath: {
+                FileManager.default.homeDirectoryForCurrentUser.path
+            },
+            whichGT: {
+                GasTownDiscovery.resolveGTCLI()
+            }
+        )
+    }
+
+    let environment: Environment
+
+    init(environment: Environment = .live) {
+        self.environment = environment
+    }
+
+    // MARK: - Public API
+
+    /// Attempt to discover a valid Town root and return a full result.
+    ///
+    /// Returns `.success` with the discovery result when a valid Town is found,
+    /// or `.failure` with a structured error describing what went wrong.
+    func discover() -> Result<TownDiscoveryResult, TownDetectionError> {
+        let gtPath = environment.whichGT()
+
+        // Phase 1: Locate a candidate Town root path.
+        let candidate = locateTownRoot()
+
+        guard let candidatePath = candidate else {
+            let searched = searchedPaths()
+            // If gt CLI is also missing, surface that as a more fundamental error.
+            if gtPath == nil {
+                return .failure(.gtCLINotFound)
+            }
+            return .failure(.noTownRoot(searchedPaths: searched))
+        }
+
+        // Phase 2: Validate the candidate.
+        var prereqs: [PrerequisiteResult] = []
+
+        prereqs.append(checkPrerequisite(.townRootExists, at: candidatePath))
+        prereqs.append(checkPrerequisite(.beadsDirectoryExists, at: candidatePath))
+        prereqs.append(checkPrerequisite(.routesFileExists, at: candidatePath))
+
+        let rigs = enumerateRigs(at: candidatePath)
+        let hasRig = !rigs.isEmpty
+        prereqs.append(PrerequisiteResult(
+            prerequisite: .atLeastOneRig,
+            passed: hasRig,
+            guidance: hasRig ? nil : String(
+                localized: "town.prerequisite.noRigs",
+                defaultValue: "No rigs found in \(candidatePath). Create a rig with 'gt rig create <name>'."
+            )
+        ))
+
+        prereqs.append(PrerequisiteResult(
+            prerequisite: .gtCLIAvailable,
+            passed: gtPath != nil,
+            guidance: gtPath != nil ? nil : String(
+                localized: "town.prerequisite.gtMissing",
+                defaultValue: "The 'gt' command-line tool is not installed or not on your PATH. Install Gas Town to use Gastown features."
+            )
+        ))
+
+        let failures = prereqs.filter { !$0.passed }
+        // Town root must exist and have a .beads directory at minimum.
+        let criticalFailures = failures.filter {
+            $0.prerequisite == .townRootExists || $0.prerequisite == .beadsDirectoryExists
+        }
+        if !criticalFailures.isEmpty {
+            return .failure(.invalidTownLayout(path: candidatePath, failures: failures))
+        }
+
+        let town = TownRoot(path: candidatePath)
+        return .success(TownDiscoveryResult(
+            town: town,
+            rigs: rigs,
+            prerequisites: prereqs,
+            gtCLIPath: gtPath
+        ))
+    }
+
+    // MARK: - Detection Strategies
+
+    /// Search order for locating the Town root.
+    private func locateTownRoot() -> String? {
+        // Strategy 1: GT_TOWN_ROOT env var (authoritative).
+        if let envRoot = environment.getenv("GT_TOWN_ROOT"),
+           !envRoot.isEmpty,
+           isTownRoot(envRoot) {
+            return envRoot
+        }
+
+        // Strategy 2: GT_ROOT env var (legacy alias).
+        if let envRoot = environment.getenv("GT_ROOT"),
+           !envRoot.isEmpty,
+           isTownRoot(envRoot) {
+            return envRoot
+        }
+
+        // Strategy 3: Walk up from cwd looking for .beads/routes.jsonl.
+        let cwd = environment.currentDirectoryPath()
+        if let found = walkUpForTownRoot(from: cwd) {
+            return found
+        }
+
+        // Strategy 4: Check ~/gt/ (common convention).
+        let home = environment.homeDirectoryPath()
+        let defaultPath = (home as NSString).appendingPathComponent("gt")
+        if isTownRoot(defaultPath) {
+            return defaultPath
+        }
+
+        return nil
+    }
+
+    /// Returns the list of paths that were searched (for error reporting).
+    private func searchedPaths() -> [String] {
+        var paths: [String] = []
+        if let envRoot = environment.getenv("GT_TOWN_ROOT"), !envRoot.isEmpty {
+            paths.append(envRoot)
+        }
+        if let envRoot = environment.getenv("GT_ROOT"), !envRoot.isEmpty, !paths.contains(envRoot) {
+            paths.append(envRoot)
+        }
+        let cwd = environment.currentDirectoryPath()
+        paths.append(cwd)
+        let home = environment.homeDirectoryPath()
+        let defaultPath = (home as NSString).appendingPathComponent("gt")
+        if !paths.contains(defaultPath) {
+            paths.append(defaultPath)
+        }
+        return paths
+    }
+
+    /// Check whether a directory looks like a Town root.
+    private func isTownRoot(_ path: String) -> Bool {
+        guard environment.isDirectory(path) else { return false }
+        let routesPath = (path as NSString).appendingPathComponent(".beads/routes.jsonl")
+        return environment.fileExists(routesPath)
+    }
+
+    /// Walk up directory parents from `start` looking for a Town root marker.
+    private func walkUpForTownRoot(from start: String) -> String? {
+        var current = start
+        let root = "/"
+        while current != root && !current.isEmpty {
+            if isTownRoot(current) {
+                return current
+            }
+            current = (current as NSString).deletingLastPathComponent
+        }
+        // Check / itself (unlikely but complete).
+        if isTownRoot(root) {
+            return root
+        }
+        return nil
+    }
+
+    // MARK: - Prerequisite Checks
+
+    private func checkPrerequisite(_ prereq: TownPrerequisite, at townPath: String) -> PrerequisiteResult {
+        switch prereq {
+        case .townRootExists:
+            let exists = environment.isDirectory(townPath)
+            return PrerequisiteResult(
+                prerequisite: prereq,
+                passed: exists,
+                guidance: exists ? nil : String(
+                    localized: "town.prerequisite.rootMissing",
+                    defaultValue: "Town root directory '\(townPath)' does not exist or is not a directory."
+                )
+            )
+
+        case .beadsDirectoryExists:
+            let beadsPath = (townPath as NSString).appendingPathComponent(".beads")
+            let exists = environment.isDirectory(beadsPath)
+            return PrerequisiteResult(
+                prerequisite: prereq,
+                passed: exists,
+                guidance: exists ? nil : String(
+                    localized: "town.prerequisite.beadsMissing",
+                    defaultValue: "Expected '.beads' directory not found at '\(townPath)'. This directory may not be a Gas Town root."
+                )
+            )
+
+        case .routesFileExists:
+            let routesPath = (townPath as NSString).appendingPathComponent(".beads/routes.jsonl")
+            let exists = environment.fileExists(routesPath)
+            return PrerequisiteResult(
+                prerequisite: prereq,
+                passed: exists,
+                guidance: exists ? nil : String(
+                    localized: "town.prerequisite.routesMissing",
+                    defaultValue: "Bead routing file 'routes.jsonl' not found in '.beads/'. Run 'gt init' to initialize the Town."
+                )
+            )
+
+        case .atLeastOneRig, .gtCLIAvailable:
+            // These are handled inline in discover() where we have the needed context.
+            return PrerequisiteResult(prerequisite: prereq, passed: true, guidance: nil)
+        }
+    }
+
+    // MARK: - Rig Enumeration
+
+    /// Scan immediate subdirectories of the Town root for rig config files.
+    func enumerateRigs(at townPath: String) -> [RigInfo] {
+        let entries = environment.contentsOfDirectory(townPath)
+        var rigs: [RigInfo] = []
+
+        for entry in entries {
+            // Skip hidden directories and known non-rig entries.
+            if entry.hasPrefix(".") { continue }
+
+            let entryPath = (townPath as NSString).appendingPathComponent(entry)
+            guard environment.isDirectory(entryPath) else { continue }
+
+            let configPath = (entryPath as NSString).appendingPathComponent("config.json")
+            guard let data = environment.contentsOfFile(configPath) else { continue }
+
+            if let rigInfo = parseRigConfig(data: data, dirName: entry, dirPath: entryPath) {
+                rigs.append(rigInfo)
+            }
+        }
+
+        return rigs.sorted { $0.name < $1.name }
+    }
+
+    /// Parse a rig's config.json into a RigInfo.
+    private func parseRigConfig(data: Data, dirName: String, dirPath: String) -> RigInfo? {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let type = json["type"] as? String,
+              type == "rig" else {
+            return nil
+        }
+
+        let name = (json["name"] as? String) ?? dirName
+        let gitURL = json["git_url"] as? String
+        let defaultBranch = json["default_branch"] as? String
+        let beadsPrefix: String?
+        if let beads = json["beads"] as? [String: Any] {
+            beadsPrefix = beads["prefix"] as? String
+        } else {
+            beadsPrefix = nil
+        }
+
+        return RigInfo(
+            name: name,
+            path: dirPath,
+            gitURL: gitURL,
+            defaultBranch: defaultBranch,
+            beadsPrefix: beadsPrefix
+        )
+    }
+
+    // MARK: - gt CLI Resolution
+
+    /// Attempt to find the `gt` binary on PATH.
+    static func resolveGTCLI() -> String? {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/which")
+        task.arguments = ["gt"]
+        let pipe = Pipe()
+        task.standardOutput = pipe
+        task.standardError = FileHandle.nullDevice
+        do {
+            try task.run()
+            task.waitUntilExit()
+            if task.terminationStatus == 0 {
+                let data = pipe.fileHandleForReading.readDataToEndOfFile()
+                let path = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
+                if let path, !path.isEmpty {
+                    return path
+                }
+            }
+        } catch {
+            // which not available or failed — gt not on PATH.
+        }
+        return nil
+    }
+}

--- a/Sources/Panels/Panel.swift
+++ b/Sources/Panels/Panel.swift
@@ -7,6 +7,7 @@ public enum PanelType: String, Codable, Sendable {
     case terminal
     case browser
     case markdown
+    case convoy
 }
 
 public enum TerminalPanelFocusIntent: Equatable {

--- a/Sources/Panels/PanelContentView.swift
+++ b/Sources/Panels/PanelContentView.swift
@@ -55,6 +55,16 @@ struct PanelContentView: View {
                     onRequestPanelFocus: onRequestPanelFocus
                 )
             }
+        case .convoy:
+            if let convoyPanel = panel as? ConvoyDetailPanel {
+                ConvoyDetailPanelView(
+                    panel: convoyPanel,
+                    isFocused: isFocused,
+                    isVisibleInUI: isVisibleInUI,
+                    portalPriority: portalPriority,
+                    onRequestPanelFocus: onRequestPanelFocus
+                )
+            }
         }
     }
 }

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -240,6 +240,10 @@ struct SessionMarkdownPanelSnapshot: Codable, Sendable {
     var filePath: String
 }
 
+struct SessionConvoyPanelSnapshot: Codable, Sendable {
+    var convoyId: String
+}
+
 struct SessionPanelSnapshot: Codable, Sendable {
     var id: UUID
     var type: PanelType
@@ -254,6 +258,7 @@ struct SessionPanelSnapshot: Codable, Sendable {
     var terminal: SessionTerminalPanelSnapshot?
     var browser: SessionBrowserPanelSnapshot?
     var markdown: SessionMarkdownPanelSnapshot?
+    var convoy: SessionConvoyPanelSnapshot?
 }
 
 enum SessionSplitOrientation: String, Codable, Sendable {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -449,6 +449,7 @@ extension Workspace {
         let terminalSnapshot: SessionTerminalPanelSnapshot?
         let browserSnapshot: SessionBrowserPanelSnapshot?
         let markdownSnapshot: SessionMarkdownPanelSnapshot?
+        let convoySnapshot: SessionConvoyPanelSnapshot?
         switch panel.panelType {
         case .terminal:
             guard let terminalPanel = panel as? TerminalPanel else { return nil }
@@ -472,6 +473,7 @@ extension Workspace {
             )
             browserSnapshot = nil
             markdownSnapshot = nil
+            convoySnapshot = nil
         case .browser:
             guard let browserPanel = panel as? BrowserPanel else { return nil }
             terminalSnapshot = nil
@@ -486,11 +488,19 @@ extension Workspace {
                 forwardHistoryURLStrings: historySnapshot.forwardHistoryURLStrings
             )
             markdownSnapshot = nil
+            convoySnapshot = nil
         case .markdown:
             guard let markdownPanel = panel as? MarkdownPanel else { return nil }
             terminalSnapshot = nil
             browserSnapshot = nil
             markdownSnapshot = SessionMarkdownPanelSnapshot(filePath: markdownPanel.filePath)
+            convoySnapshot = nil
+        case .convoy:
+            guard let convoyPanel = panel as? ConvoyDetailPanel else { return nil }
+            terminalSnapshot = nil
+            browserSnapshot = nil
+            markdownSnapshot = nil
+            convoySnapshot = SessionConvoyPanelSnapshot(convoyId: convoyPanel.convoyId)
         }
 
         return SessionPanelSnapshot(
@@ -506,7 +516,8 @@ extension Workspace {
             ttyName: ttyName,
             terminal: terminalSnapshot,
             browser: browserSnapshot,
-            markdown: markdownSnapshot
+            markdown: markdownSnapshot,
+            convoy: convoySnapshot
         )
     }
 
@@ -681,6 +692,17 @@ extension Workspace {
             }
             applySessionPanelMetadata(snapshot, toPanelId: markdownPanel.id)
             return markdownPanel.id
+        case .convoy:
+            guard let convoyId = snapshot.convoy?.convoyId,
+                  let convoyPanel = newConvoySurface(
+                    inPane: paneId,
+                    convoyId: convoyId,
+                    focus: false
+                  ) else {
+                return nil
+            }
+            applySessionPanelMetadata(snapshot, toPanelId: convoyPanel.id)
+            return convoyPanel.id
         }
     }
 
@@ -6719,6 +6741,7 @@ final class Workspace: Identifiable, ObservableObject {
         static let terminal = "terminal"
         static let browser = "browser"
         static let markdown = "markdown"
+        static let convoy = "convoy"
     }
 
     enum PanelShellActivityState: String {
@@ -7232,6 +7255,8 @@ final class Workspace: Identifiable, ObservableObject {
             return SurfaceKind.browser
         case .markdown:
             return SurfaceKind.markdown
+        case .convoy:
+            return SurfaceKind.convoy
         }
     }
 
@@ -9253,6 +9278,139 @@ final class Workspace: Identifiable, ObservableObject {
 
         installMarkdownPanelSubscription(markdownPanel)
         return markdownPanel
+    }
+
+    // MARK: - Convoy Panel
+
+    @discardableResult
+    func newConvoySurface(
+        inPane paneId: PaneID,
+        convoyId: String,
+        focus: Bool? = nil
+    ) -> ConvoyDetailPanel? {
+        let shouldFocusNewTab = focus ?? (bonsplitController.focusedPaneId == paneId)
+        let previousFocusedPanelId = focusedPanelId
+        let previousHostedView = focusedTerminalPanel?.hostedView
+
+        let convoyPanel = ConvoyDetailPanel(workspaceId: id, convoyId: convoyId)
+        panels[convoyPanel.id] = convoyPanel
+        panelTitles[convoyPanel.id] = convoyPanel.displayTitle
+
+        guard let newTabId = bonsplitController.createTab(
+            title: convoyPanel.displayTitle,
+            icon: convoyPanel.displayIcon,
+            kind: SurfaceKind.convoy,
+            isDirty: convoyPanel.isDirty,
+            isLoading: false,
+            isPinned: false,
+            inPane: paneId
+        ) else {
+            panels.removeValue(forKey: convoyPanel.id)
+            panelTitles.removeValue(forKey: convoyPanel.id)
+            return nil
+        }
+
+        surfaceIdToPanelId[newTabId] = convoyPanel.id
+        if shouldFocusNewTab {
+            bonsplitController.focusPane(paneId)
+            bonsplitController.selectTab(newTabId)
+            applyTabSelection(tabId: newTabId, inPane: paneId)
+        } else {
+            preserveFocusAfterNonFocusSplit(
+                preferredPanelId: previousFocusedPanelId,
+                splitPanelId: convoyPanel.id,
+                previousHostedView: previousHostedView
+            )
+        }
+
+        installConvoyPanelSubscription(convoyPanel)
+        return convoyPanel
+    }
+
+    func newConvoySplit(
+        from panelId: UUID,
+        orientation: SplitOrientation,
+        insertFirst: Bool = false,
+        convoyId: String,
+        focus: Bool = true
+    ) -> ConvoyDetailPanel? {
+        guard let sourceTabId = surfaceIdFromPanelId(panelId) else { return nil }
+        var sourcePaneId: PaneID?
+        for paneId in bonsplitController.allPaneIds {
+            let tabs = bonsplitController.tabs(inPane: paneId)
+            if tabs.contains(where: { $0.id == sourceTabId }) {
+                sourcePaneId = paneId
+                break
+            }
+        }
+
+        guard let paneId = sourcePaneId else { return nil }
+
+        let convoyPanel = ConvoyDetailPanel(workspaceId: id, convoyId: convoyId)
+        panels[convoyPanel.id] = convoyPanel
+        panelTitles[convoyPanel.id] = convoyPanel.displayTitle
+
+        let newTab = Bonsplit.Tab(
+            title: convoyPanel.displayTitle,
+            icon: convoyPanel.displayIcon,
+            kind: SurfaceKind.convoy,
+            isDirty: convoyPanel.isDirty,
+            isLoading: false,
+            isPinned: false
+        )
+        surfaceIdToPanelId[newTab.id] = convoyPanel.id
+        let previousFocusedPanelId = focusedPanelId
+
+        isProgrammaticSplit = true
+        defer { isProgrammaticSplit = false }
+        guard bonsplitController.splitPane(paneId, orientation: orientation, withTab: newTab, insertFirst: insertFirst) != nil else {
+            surfaceIdToPanelId.removeValue(forKey: newTab.id)
+            panels.removeValue(forKey: convoyPanel.id)
+            panelTitles.removeValue(forKey: convoyPanel.id)
+            return nil
+        }
+
+        let previousHostedView = focusedTerminalPanel?.hostedView
+        if focus {
+            previousHostedView?.suppressReparentFocus()
+            focusPanel(convoyPanel.id)
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                previousHostedView?.clearSuppressReparentFocus()
+            }
+        } else {
+            preserveFocusAfterNonFocusSplit(
+                preferredPanelId: previousFocusedPanelId,
+                splitPanelId: convoyPanel.id,
+                previousHostedView: previousHostedView
+            )
+        }
+
+        installConvoyPanelSubscription(convoyPanel)
+        return convoyPanel
+    }
+
+    private func installConvoyPanelSubscription(_ convoyPanel: ConvoyDetailPanel) {
+        let subscription = convoyPanel.$displayTitle
+            .removeDuplicates()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self, weak convoyPanel] newTitle in
+                guard let self,
+                      let convoyPanel,
+                      let tabId = self.surfaceIdFromPanelId(convoyPanel.id) else { return }
+                guard let existing = self.bonsplitController.tab(tabId) else { return }
+
+                if self.panelTitles[convoyPanel.id] != newTitle {
+                    self.panelTitles[convoyPanel.id] = newTitle
+                }
+                let resolvedTitle = self.resolvedPanelTitle(panelId: convoyPanel.id, fallback: newTitle)
+                guard existing.title != resolvedTitle else { return }
+                self.bonsplitController.updateTab(
+                    tabId,
+                    title: resolvedTitle,
+                    hasCustomTitle: self.panelCustomTitles[convoyPanel.id] != nil
+                )
+            }
+        panelSubscriptions[convoyPanel.id] = subscription
     }
 
     /// Tear down all panels in this workspace, freeing their Ghostty surfaces.


### PR DESCRIPTION
## Summary
- Adds convoy detail rendering to workspace views
- Uses convoy pipeline from TASK-013 and Beads adapter from TASK-011
- Shows tracked issues, progress context, and contextual operator actions
- Also includes TASK-013 convoy pipeline commits (cherry-picked dependency base)

## Task refs
- TASK-014 (gm-1cc)
- TASK-013 (gm-4dd) — dependency commits included

## Test plan
- [ ] Build with `./scripts/reload.sh --tag task-014-convoy-detail`
- [ ] Verify convoy detail renders tracked issues
- [ ] Verify operator action links are present

🤖 Generated with [Claude Code](https://claude.com/claude-code)